### PR TITLE
add alignment for LDM instruction

### DIFF
--- a/src/alphanum_byte.c
+++ b/src/alphanum_byte.c
@@ -57,6 +57,25 @@ unsigned char off_gen (unsigned char c){
 
 
 
+/* generate an alphanumeric offset such that c+offset is also alphanumeric, aligned by 4 bytes */
+/* ======================================================================= */
+unsigned char off_gen_aligned (unsigned char c){
+    if (c >= 0 && c <= 0x4a) {
+        unsigned char max = 16 * 7 + 10 - c;
+        while (1) {
+            unsigned char x = alphanumeric_get_byte_ltmax(max);
+            if (alphanumeric_check(c + x) && (x % 4 == 0)) {
+                return x;
+            }
+        }
+    } 
+    else {
+        return 0;
+    }
+}
+
+
+
 /* return an alphanumeric value ret such that c XOR ret is also alphanumeric */
 /* ========================================================================= */
 unsigned char alphanumeric_get_complement(unsigned char c) {

--- a/src/builder.c
+++ b/src/builder.c
@@ -250,7 +250,7 @@ void DecoderBuilder(struct Sshellcode* output, struct Sshellcode* input, unsigne
 	lmul(output, m, reglH, reglL);*/
 	
 	
-		unsigned char c = off_gen(24);
+		unsigned char c = off_gen_aligned(24);
 		unsigned char arr5[] = {2,4,6,8,10,12,14,16,18};
 		unsigned char arr6[] = {4,6};
 		unsigned char arr7[] = {1,2,4,8};


### PR DESCRIPTION
Shellcode generated by previous version contains unaligned `ldmdbpl r3!, {r0, r1, r2, r6, sl, lr}`, which will cause target process hang up or crash.
Added off_gen_aligned() function to address this issue.
https://cwshu.github.io/arm_virt_notes/notes/misc/alignment_fault.html